### PR TITLE
fixed settings desync when modlist is changed

### DIFF
--- a/long-reach_0.0.12/control.lua
+++ b/long-reach_0.0.12/control.lua
@@ -6,7 +6,7 @@ script.on_configuration_changed(function (data)
 	apply_long_reach_settings()		
 end)
 
-script.on_event(defines.events.on_runtime_mod_setting_changed,function ()
+script.on_event({defines.events.on_runtime_mod_setting_changed, defines.events.on_player_joined_game, defines.events.on_player_changed_force},function ()
 	apply_long_reach_settings()
 end)
 


### PR DESCRIPTION
To reproduce:
- install long-reach
- toggle, install or remove any mod or update game/mod version

After this player settings are reseted to default values and long-reach reapplied only after mod settings changed manually by player (`on_runtime_mod_setting_changed` event).

This should fix that and apply long reach settings each time player joins to the game.
